### PR TITLE
Implement upstream fetch mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies
 /node_modules
+**/node_modules/.vitest
 
 # Production
 /build
@@ -20,5 +21,3 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-
-dummy-change

--- a/.idea/runConfigurations/fetchUpstream.xml
+++ b/.idea/runConfigurations/fetchUpstream.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="fetchUpstream" type="js.build_tools.npm" nameIsGenerated="true">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="fetchUpstream" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/framework/upstreamSync/config.yaml
+++ b/framework/upstreamSync/config.yaml
@@ -1,0 +1,42 @@
+teachingDevPath: ~/repos/teaching-dev
+expectedBranch: feature-branch
+controlledElements:
+  - src: src/api/
+    dst: src/api
+  - src: src/components/
+    dst: src/sharedComponents
+  - src: src/hooks/
+    dst: src/hooks
+  - src: src/models/
+    dst: src/models
+  - src: src/plugins/
+    dst: src/sharedPlugins
+  - src: src/stores/
+    dst: src/stores/shared
+    ignore:
+      - rootStore.ts
+    protect:
+      - rootStore.ts
+  - src: src/authConfig.ts
+    dst: src/
+  - src: vitest.config.ts
+    dst: vitest.config.ts
+  - src: docs/Komponentengalerie/
+    dst: content/material/Components-Gallery/99-Shared-Components
+
+# Convention if you need to add custom files to a controlled directory:
+#  - rename `someDir` to `sharedSomeDir`
+#  - update the dst path in the controlledElements dict
+#  - create a new `someDir` and add custom elements there
+
+# TODO: In fetch reports, notify about changes to...
+#  - src/css/**
+#  - src/stores/rootStore.ts
+#  - .env.example
+#  - .babel.config.js
+#  - docusaurus.config.ts
+#  - package.json
+
+# TODO: See if sync required...
+#  - src/theme
+#  - src/pages

--- a/framework/upstreamSync/config.yaml
+++ b/framework/upstreamSync/config.yaml
@@ -23,19 +23,18 @@ controlledElements:
     dst: vitest.config.ts
   - src: docs/Komponentengalerie/
     dst: content/material/Components-Gallery/99-Shared-Components
+watch:
+  - src/css/**
+  - src/stores/rootStore.ts
+  - .env.example
+  - .babel.config.js
+  - docusaurus.config.ts
+  - package.json
 
 # Convention if you need to add custom files to a controlled directory:
 #  - rename `someDir` to `sharedSomeDir`
 #  - update the dst path in the controlledElements dict
 #  - create a new `someDir` and add custom elements there
-
-# TODO: In fetch reports, notify about changes to...
-#  - src/css/**
-#  - src/stores/rootStore.ts
-#  - .env.example
-#  - .babel.config.js
-#  - docusaurus.config.ts
-#  - package.json
 
 # TODO: See if sync required...
 #  - src/theme

--- a/framework/upstreamSync/fetchUpstream.ts
+++ b/framework/upstreamSync/fetchUpstream.ts
@@ -71,10 +71,30 @@ async function sync() {
   }
 }
 
+async function updateSyncMarker(): Promise<void> {
+  try {
+    const { stdout: currentCommit } = await exec('git rev-parse HEAD', { cwd: teachingDevPath });
+    const trimmedCommit = currentCommit.trim();
+
+    const syncMarkerPath = path.join(repoRootPath, '.upstreamSync');
+    if (!fs.existsSync(syncMarkerPath)) {
+      fs.writeFileSync(syncMarkerPath, '');
+    }
+
+    const syncMarkerEntry = `CURRENT_COMMIT=${trimmedCommit}`;
+    fs.writeFileSync(syncMarkerPath, syncMarkerEntry, 'utf8');
+
+    console.log(`✅  Successfully updated ${syncMarkerPath} with commit SHA: ${trimmedCommit}`);
+  } catch (error) {
+    console.error('An error occurred:', error);
+  }
+}
+
 async function fetchUpstream(): Promise<void> {
   try {
     await pullTeachingDev();
     await sync();
+    await updateSyncMarker()
   } catch (error) {
     console.error('An unexpected error occurred:', error);
     process.exit(1);

--- a/framework/upstreamSync/fetchUpstream.ts
+++ b/framework/upstreamSync/fetchUpstream.ts
@@ -1,0 +1,84 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import {exec as execCallback, execSync} from 'child_process';
+import {promisify} from 'util';
+import * as yaml from 'js-yaml';
+import {Config, ControlledElementConfig} from './models';
+import {expandTilde} from "./helper";
+
+const exec = promisify(execCallback);
+
+const config = yaml.load(fs.readFileSync(path.resolve(__dirname, './config.yaml'), 'utf8')) as Config;
+const repoRootPath = process.cwd();
+const teachingDevPath = path.resolve(expandTilde(config.teachingDevPath.trim()));
+
+async function pullTeachingDev() {
+  if (!fs.existsSync(teachingDevPath)) {
+    console.error(`Repo ${teachingDevPath} does not exist.`);
+    process.exit(1);
+  }
+
+  console.log(`🕊️Performing branch check...`);
+
+  process.chdir(teachingDevPath);
+
+  const currentBranch: string = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
+  if (currentBranch !== config.expectedBranch) {
+    console.error('Error: teaching-dev is not on the expected branch.');
+    console.error(`Expected: ${config.expectedBranch}`);
+    console.error(`Current: ${currentBranch}`);
+    process.exit(1);
+  }
+
+  console.log(`✅  Branch check passed; teaching-dev is on '${config.expectedBranch}' as expected.`);
+  console.log('🚜 Performing git pull...');
+
+  try {
+    await exec('git pull');
+    console.log('✅  Successfully pulled teaching-dev.');
+  } catch (error) {
+    console.error('Error: Failed to pull teaching-dev.');
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+function createRsyncCommand({src, dst, ignore, protect}: ControlledElementConfig): string {
+  const excludePatterns = ignore ? ignore.map(pattern => `--exclude='${pattern}'`).join(' ') : '';
+  const protectPatterns = protect ? protect.map(pattern => `--filter='protect ${pattern}'`).join(' ') : '';
+
+  return `rsync -av --delete ${excludePatterns} \
+                ${protectPatterns} \
+                ${path.join(teachingDevPath, src)} \
+                ${path.join(repoRootPath, dst)} \
+                --delete-after \
+                --prune-empty-dirs`;
+}
+
+async function sync() {
+  for (const element of config.controlledElements) {
+    const rsyncCommand = createRsyncCommand(element);
+    console.log(rsyncCommand);
+
+    try {
+      await exec(rsyncCommand);
+      console.log('Rsync completed successfully.');
+    } catch (error) {
+      console.error('Error: Failed to execute rsync.');
+      console.error(error);
+      process.exit(1);
+    }
+  }
+}
+
+async function fetchUpstream(): Promise<void> {
+  try {
+    await pullTeachingDev();
+    await sync();
+  } catch (error) {
+    console.error('An unexpected error occurred:', error);
+    process.exit(1);
+  }
+}
+
+fetchUpstream();

--- a/framework/upstreamSync/fetchUpstream.ts
+++ b/framework/upstreamSync/fetchUpstream.ts
@@ -58,11 +58,10 @@ function createRsyncCommand({src, dst, ignore, protect}: ControlledElementConfig
 async function sync() {
   for (const element of config.controlledElements) {
     const rsyncCommand = createRsyncCommand(element);
-    console.log(rsyncCommand);
 
     try {
       await exec(rsyncCommand);
-      console.log('Rsync completed successfully.');
+      console.log(`✅  Rsync command for controlled element ${element.dst} completed successfully.`);
     } catch (error) {
       console.error('Error: Failed to execute rsync.');
       console.error(error);

--- a/framework/upstreamSync/helper.ts
+++ b/framework/upstreamSync/helper.ts
@@ -1,0 +1,9 @@
+import * as path from "path";
+import * as os from "os";
+
+export function expandTilde(filePath: string): string {
+  if (filePath[0] === '~') {
+    return path.join(os.homedir(), filePath.slice(1));
+  }
+  return filePath;
+}

--- a/framework/upstreamSync/models.ts
+++ b/framework/upstreamSync/models.ts
@@ -1,0 +1,12 @@
+export interface ControlledElementConfig {
+  src: string;
+  dst: string;
+  ignore?: string[];
+  protect?: string[];
+}
+
+export interface Config {
+  teachingDevPath: string;
+  expectedBranch: string;
+  controlledElements: ControlledElementConfig[];
+}

--- a/framework/upstreamSync/models.ts
+++ b/framework/upstreamSync/models.ts
@@ -9,4 +9,5 @@ export interface Config {
   teachingDevPath: string;
   expectedBranch: string;
   controlledElements: ControlledElementConfig[];
+  watch: string[]
 }

--- a/framework/upstreamSync/tsconfig.json
+++ b/framework/upstreamSync/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "../../build/upstreamSync",
+    "rootDir": "./",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "baseUrl": "../../",
+    "paths": {
+      "*": ["node_modules/*"]
+    }
+  },
+  "include": [
+    "fetchUpstream.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "fetchUpstream": "ts-node framework/upstreamSync/fetchUpstream.ts"
   },
   "dependencies": {
     "@azure/msal-browser": "^3.18.0",
@@ -30,6 +31,7 @@
     "@mdx-js/react": "^3.0.0",
     "@radial-color-picker/react-color-picker": "^4.0.1",
     "@types/jest": "^29.5.11",
+    "@types/js-yaml": "^4.0.9",
     "@types/lodash": "^4.14.202",
     "axios": "^1.7.2",
     "babel-plugin-transform-class-properties": "^6.24.1",
@@ -40,6 +42,7 @@
     "html-to-image": "^1.11.11",
     "jest": "^29.7.0",
     "js-sha256": "^0.11.0",
+    "js-yaml": "^4.1.0",
     "katex": "^0.16.9",
     "known-css-properties": "^0.34.0",
     "lodash": "^4.17.21",
@@ -56,6 +59,7 @@
     "remark-math": "^6.0.0",
     "rlcolormixer": "^0.6.0",
     "socket.io-client": "^4.7.5",
+    "ts-node": "^10.9.2",
     "typed.js": "^2.1.0",
     "uuid": "^10.0.0",
     "yaml": "^2.3.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1412,6 +1412,13 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@discoveryjs/json-ext@0.5.7":
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
@@ -2134,6 +2141,11 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.24"
 
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
+  integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
+
 "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
@@ -2161,6 +2173,14 @@
   version "1.4.15"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.20", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.20"
@@ -2482,6 +2502,26 @@
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.11.tgz#6ee46400685f130e278128c7b38b7e031ff5b2f2"
+  integrity sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
+  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
+
 "@types/acorn@^4.0.0":
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/@types/acorn/-/acorn-4.0.6.tgz#d61ca5480300ac41a7d973dd5b84d0a591154a22"
@@ -2743,6 +2783,11 @@
   dependencies:
     expect "^29.0.0"
     pretty-format "^29.0.0"
+
+"@types/js-yaml@^4.0.9":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.9.tgz#cd82382c4f902fed9691a2ed79ec68c5898af4c2"
+  integrity sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==
 
 "@types/json-schema@*", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.15"
@@ -3120,10 +3165,22 @@ acorn-walk@^8.0.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.1.tgz#2f10f5b69329d90ae18c58bf1fa8fccd8b959a43"
   integrity sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==
 
+acorn-walk@^8.1.1:
+  version "8.3.3"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.3.tgz#9caeac29eefaa0c41e3d4c65137de4d6f34df43e"
+  integrity sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==
+  dependencies:
+    acorn "^8.11.0"
+
 acorn@^8.0.0, acorn@^8.0.4, acorn@^8.7.1, acorn@^8.8.2:
   version "8.11.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
   integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
+
+acorn@^8.11.0, acorn@^8.4.1:
+  version "8.12.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.12.1.tgz#71616bdccbe25e27a54439e0046e89ca76df2248"
+  integrity sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==
 
 address@^1.0.1, address@^1.1.2:
   version "1.2.2"
@@ -3274,6 +3331,11 @@ anymatch@^3.0.3, anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 arg@^5.0.0:
   version "5.0.2"
@@ -4220,6 +4282,11 @@ create-jest@^29.7.0:
     jest-util "^29.7.0"
     prompts "^2.0.1"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -4864,6 +4931,11 @@ diff-sequences@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
   integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diff@^5.0.0:
   version "5.1.0"
@@ -7211,7 +7283,7 @@ make-dir@^4.0.0:
   dependencies:
     semver "^7.5.3"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -10448,6 +10520,25 @@ ts-jest@^29.1.1:
     semver "^7.5.3"
     yargs-parser "^21.0.1"
 
+ts-node@^10.9.2:
+  version "10.9.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
+  integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
 tslib@^2.0.3, tslib@^2.6.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
@@ -10722,6 +10813,11 @@ uvu@^0.5.0:
     diff "^5.0.0"
     kleur "^4.0.3"
     sade "^1.7.3"
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-to-istanbul@^9.0.1:
   version "9.2.0"
@@ -11094,6 +11190,11 @@ yargs@^17.3.1:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
- Configure mappings between `teaching-dev` and `teaching-website` in `framework/builder/upstreamSync/config.yaml`.
  - `controlledElements` specify which files and directories in `teaching-website` are controlled by `teaching-dev`.
    - Use `ignore` to prevent the script from copying a given file from `teaching-dev`.
    - Use `protect` to prevent the script from deleting a given file in `teaching-website` if it's not present in `teaching-dev`.
  - Use `watch` to specify glob patterns for files that are not controlled by `teaching-dev`, if you still want to be aware of changes to them since the last fetch.
- Run `yarn run fetchUpstream` or the `fetchUpstream` IntelliJ run config to run the script.
- Script creates a file `.upstreamSync` to keep track of the latest synced revision hash of `teaching-dev`.